### PR TITLE
Fix error 'jq: error: Cannot iterate over null' 

### DIFF
--- a/envwarden
+++ b/envwarden
@@ -25,6 +25,15 @@ usage()
     echo "You can use ~/.envwarden to store your credentials (just email, or email:password)"
 }
 
+check_version()
+{
+    printf '%s\n%s' $2 $3 | sort -C -V
+    if [ $? == 0 ]; then
+        (>&2 echo "$1 $2 found, version $3 or higher is needed")
+        exit 1
+    fi
+}
+
 while [[ $# > 0 ]]; do
     key="$1"
     case $key in
@@ -47,6 +56,17 @@ while [[ $# > 0 ]]; do
     esac
     shift
 done
+
+which jq > /dev/null 2>&1
+
+if [ $? != 0 ]; then
+  (>&2 echo "jq command not found" )
+  exit 1
+fi
+
+JQ_VERSION=`jq --version 2>&1 | cut -f3 -d" "`
+
+check_version "jq" "$JQ_VERSION" "1.6"
 
 if [[ -f $HOME/.envwarden ]]; then
     IFS=':' read -r bw_login bw_password <<< `cat $HOME/.envwarden`
@@ -73,4 +93,4 @@ while read -r key; do
         quoted_value="$(echo "$value" | sed "s/'/'\"'\"'/g")"
         echo export \'$quoted_key\'=\'$quoted_value\'
     fi
-done < <(bw list items --search "$SEARCH" |jq -r '.[].fields[] | select(.name != null) | select(.value != null) | .name, .value')
+done < <(bw list items --search "$SEARCH" |jq -r '.[].fields[]? | select(.name != null) | select(.value != null) | .name, .value')


### PR DESCRIPTION
in case selected item does not contain fields, jq will return error 'jq: error: Cannot iterate over null' .
This can be fixed with '[]?', but this is only supported by newer versions of jq
