### PR TITLE
Dont logout if the BW_SESSION env var is already set

### DIFF
--- a/envwarden
+++ b/envwarden
@@ -62,14 +62,17 @@ while [[ $# > 0 ]]; do
     shift
 done
 
-if [[ -f $HOME/.envwarden ]]; then
-    IFS=':' read -r bw_login bw_password <<< `cat $HOME/.envwarden`
-else
-    (>&2 echo ".envwarden file not found in $HOME ... prompting for credentials")
+if [ -z "$BW_SESSION" ]; then
+    if [[ -f $HOME/.envwarden ]]; then
+        IFS=':' read -r bw_login bw_password <<< `cat $HOME/.envwarden`
+    else
+        (>&2 echo ".envwarden file not found in $HOME ... prompting for credentials")
+    fi
+
+    bw logout > /dev/null
+    export BW_SESSION="`bw login $bw_login $bw_password --raw`"
 fi
 
-bw logout > /dev/null
-export BW_SESSION="`bw login $bw_login $bw_password --raw`"
 bw sync > /dev/null
 if [[ $? != 0 ]]; then
     (>&2 echo "unable to login or sync with bitwarden.")


### PR DESCRIPTION
Hi, i've started to integrate envwarden into my server setup. 
However i've noticed that an existing BW session was always reset, and the script required me to either place my bw-credentials into a file (since literally all my credentials are there, a big no-no for me), or to interactively type in my password every time i call the script (since i use 2FA and need multiple runs of the script, also not a great solution).
Therefore I added a check whether there already is a valid session key before requesting a new login.

Thanks for your work, this script is as useful as it is simple- i love it!
Best, Stephan